### PR TITLE
fix(terminal): missing return caused mismatched type error

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -161,7 +161,7 @@ impl Terminal {
             #[cfg(target_os = "macos")]
             {
                 if !macos_dark_mode_active() {
-                    Ok(ThemeStyle::Light.into())
+                    return Ok(ThemeStyle::Light.into());
                 }
             }
 


### PR DESCRIPTION
The repository as of 2022-08-14 couldn't be compiled using "cargo build" due to a mismatched type error.
Fixed it by adding a missing return statement.