### PR TITLE
Save custom initial delay

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -20,7 +20,7 @@ use rand::{seq::SliceRandom, thread_rng};
 use crate::{
     github::{GistData, Github},
     terminal::Terminal,
-    Config, Result, CONFIG,
+    Result, ARGS, CONFIG,
 };
 
 /// The prompt to be shown before the options in [`Terminal::print_round_info`].
@@ -76,6 +76,10 @@ impl Drop for Game {
             self.points.to_string().green().bold()
         );
 
+        let mut new_config = CONFIG.clone();
+
+        let mut needs_writing: bool = false;
+
         if self.points > CONFIG.high_score {
             if CONFIG.high_score > 0 {
                 println!(
@@ -87,11 +91,18 @@ impl Drop for Game {
                 );
             }
 
-            let new_config = Config {
-                high_score: self.points,
-                ..CONFIG.clone()
-            };
+            new_config.high_score = self.points;
 
+            needs_writing = true;
+        }
+
+        if let Some(initial_delay) = ARGS.wait {
+            new_config.delay = Some(initial_delay);
+            needs_writing = true;
+        }
+
+        if needs_writing {
+            // TODO Maybe handle the case of a failed `store`
             let _config = confy::store("guess-that-lang", new_config);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,8 +29,8 @@ pub struct Args {
     token: Option<String>,
 
     /// the number of ms to wait before revealing code
-    #[argh(short = 'w', option, default = "1500")]
-    wait: u64,
+    #[argh(short = 'w', option)]
+    wait: Option<u64>,
 
     /// whether or not to reveal lines in random order
     #[argh(short = 's', switch)]
@@ -47,8 +47,11 @@ pub struct Config {
     high_score: u32,
     token: String,
     theme: Option<ThemeStyle>,
+    delay: Option<u64>,
 }
 
+pub const DEFAULT_INITIAL_DELAY: u64 = 1500;
+pub const CODE_DELAY: u64 = 1500;
 lazy_static! {
     pub static ref ARGS: Args = argh::from_env();
     pub static ref CONFIG: Config = confy::load("guess-that-lang").unwrap();

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -44,9 +44,9 @@ impl TryFrom<Option<String>> for ThemeStyle {
     type Error = ();
 
     fn try_from(opt: Option<String>) -> result::Result<Self, Self::Error> {
-        match opt {
-            Some(string) if string == "dark" => Ok(Self::Dark),
-            Some(string) if string == "light" => Ok(Self::Light),
+        match opt.ok_or(())?.as_str() {
+            "dark" => Ok(Self::Dark),
+            "light" => Ok(Self::Light),
             _ => Err(()),
         }
     }
@@ -330,7 +330,12 @@ impl Terminal {
                 continue;
             }
 
-            let millis = if is_first_line { ARGS.wait } else { 1500 };
+            let millis = if is_first_line {
+                ARGS.wait
+                    .unwrap_or_else(|| CONFIG.delay.unwrap_or(crate::DEFAULT_INITIAL_DELAY))
+            } else {
+                crate::CODE_DELAY
+            };
             is_first_line = false;
 
             // The receiver will be notified when the user has selected an


### PR DESCRIPTION
Basically the title. Whenever the user requests a custom delay using the `--wait` flag, this delay gets saved in the config, just like the theme and the GH token. Also a few minor style suggestions.